### PR TITLE
Do not abort on table click.

### DIFF
--- a/grails-app/views/regions/region.gsp
+++ b/grails-app/views/regions/region.gsp
@@ -153,8 +153,7 @@
                        aa-href="${g.createLink(controller: 'region', action: 'showGroups', params: [regionFid: region.fid, regionType: region.type, regionName: region.name, regionPid: region.pid])}"
                        aa-js-before="setHubConfig();"
                        aa-js-after="regionWidget.groupsLoaded();"
-                       aa-refresh-zones="groupsZone"
-                       aa-queue="abort">
+                       aa-refresh-zones="groupsZone">
                     <thead>
                     <tr>
                         <th class="text-center"><g:message code="explore.by.group"/></th>
@@ -202,8 +201,7 @@
                        aa-href="${g.createLink(controller: 'region', action: 'showSpeciesLists')}"
                        aa-js-before="setHubConfig();"
                        aa-js-after="regionWidget.speciesListsLoaded();"
-                       aa-refresh-zones="speciesListsZone"
-                       aa-queue="abort">
+                       aa-refresh-zones="speciesListsZone">
                     <thead>
                     <tr>
                         <th class="text-center"><g:message code="specieslists"/></th>


### PR DESCRIPTION
when first opening the page, the new request for species list data, would cancel the queued request for groups data. This caused the startup to fail and the spinner to keep showing until a mouse click would reload the groups data.