### PR TITLE
#767

### DIFF
--- a/grails-app/services/au/org/ala/regions/MetadataService.groovy
+++ b/grails-app/services/au/org/ala/regions/MetadataService.groovy
@@ -230,10 +230,10 @@ class MetadataService {
     }
 
     def getSpeciesLists() {
-        String url = "${SPECIES_LIST_URL}/ws/speciesList"
+        String url = "${SPECIES_LIST_URL}/ws/speciesList?isAuthoritative=eq:true&max=1000"
         def speciesLists = getJSON(url)
 
-        speciesLists.lists.findAll{it.isAuthoritative}.collect { item ->
+        speciesLists.lists.collect { item ->
                     [
                             dataResourceUid: item.dataResourceUid,
                             listName       : item.listName,


### PR DESCRIPTION
- bugfix: fetch the full list of Authoritative species lists (gave it 1000 as limit, should be enough) instead of fetching all lists and post-filtering it and losing lists because the default fetch size is rather small (25)