### PR TITLE
inbo/vlaams-biodiversiteitsportaal#959

### DIFF
--- a/grails-app/services/au/org/ala/regions/MetadataService.groovy
+++ b/grails-app/services/au/org/ala/regions/MetadataService.groovy
@@ -231,7 +231,7 @@ class MetadataService {
     }
 
     def getSpeciesLists() {
-        String url = "${SPECIES_LIST_URL}/ws/speciesList?isAuthoritative=eq:true&max=1000"
+        String url = "${SPECIES_LIST_URL}/ws/speciesList?isRegionsApproved=eq:true&max=1000"
         def speciesLists = getJSON(url)
 
         speciesLists.lists.collect { item ->


### PR DESCRIPTION
- to show in species lists tab: fetch species lists with isRegionsApproved=true. It is expected that all Authoritative(Gezaghebbend) lists have isRegionsApproved flag set to true.